### PR TITLE
fix: DOCS - mention the `onload` event

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,26 +48,29 @@ $ npm i @maplibre/maplibre-gl-directions
 // Import the plugin
 import MaplibreGlDirections from "@maplibre/maplibre-gl-directions";
 
-// Create an instance of the default class
-const directions = new MaplibreGlDirections(map);
+// Make sure to create a MaplibreGlDirections instance only after the map is loaded
+map.on("load", () => {
+  // Create an instance of the default class
+  const directions = new MaplibreGlDirections(map);
 
-// Enable interactivity (if needed)
-directions.interactive = true;
+  // Enable interactivity (if needed)
+  directions.interactive = true;
 
-// Set the waypoints programmatically
-directions.setWaypoints([
-  [-73.8271025, 40.8032906],
-  [-73.8671258, 40.82234996],
-]);
+  // Set the waypoints programmatically
+  directions.setWaypoints([
+    [-73.8271025, 40.8032906],
+    [-73.8671258, 40.82234996],
+  ]);
 
-// Remove waypoints
-directions.removeWaypoint(0);
+  // Remove waypoints
+  directions.removeWaypoint(0);
 
-// Add waypoints
-directions.addWaypoint([-73.8671258, 40.82234996], 0);
+  // Add waypoints
+  directions.addWaypoint([-73.8671258, 40.82234996], 0);
 
-// Remove everything plugin-related from the map
-directions.clear();
+  // Remove everything plugin-related from the map
+  directions.clear();
+});
 ```
 
 Check out the [Demo](https://maplibre.org/maplibre-gl-directions/#/) or dive right into the [API Docs](https://maplibre.org/maplibre-gl-directions/api) for more!

--- a/doc/BASIC_USAGE.md
+++ b/doc/BASIC_USAGE.md
@@ -1,14 +1,14 @@
 # Basic Usage
 
-**❗ Please note that all the exposed API is a subject to change until the plugin reaches its stable state! ❗**
-
-Start by importing the plugin. Then create an instance of the imported {@link default|`MaplibreGlDirections`} class passing to the constructor a map instance and optionally a {@link MaplibreGlDirectionsOptions|configuration object}.
+Start by importing the plugin. Then, when the map is loaded, create an instance of the imported {@link default|`MaplibreGlDirections`} class passing to the constructor a map instance and optionally a {@link MaplibreGlDirectionsOptions|configuration object}.
 
 ```typescript
 import MaplibreGlDirections from "@maplibre/maplibre-gl-directions";
 
-const directions = new MaplibreGlDirections(map, {
-  // optional configuration
+map.on("load", () => {
+  const directions = new MaplibreGlDirections(map, {
+    // optional configuration
+  });
 });
 ```
 


### PR DESCRIPTION
It's important to mention that the `onload` event must have already been fired when the directions instance is created. The current docs omit that info.