### PR TITLE
Add an example that showcases origin and destination styling

### DIFF
--- a/demo/src/examples/4 Origin and Destination.vue
+++ b/demo/src/examples/4 Origin and Destination.vue
@@ -1,0 +1,80 @@
+<template>
+  <app-sidebar>
+    <template #title>{{ name }}</template>
+
+    <p>
+      In this example the default layers used by the plugin are augmented with an additional "symbol" layer which is
+      only rendered for the ORIGIN and DESTINATION waypoints.
+    </p>
+
+    <p>
+      <strong>Note</strong> how you don't need to re-define all the layers from scratch thanks to the exported
+      <code>layersFactory</code> function that returns all the default layers allowing for their augmentation and
+      modification.
+    </p>
+  </app-sidebar>
+
+  <div ref="mapRef" class="shadow-xl" />
+</template>
+
+<script setup lang="ts">
+  import { computed, onMounted, ref } from "vue";
+  import { useRoute } from "vue-router";
+  import AppSidebar from "../components/AppSidebar.vue";
+  import maplibregl from "maplibre-gl";
+  import "maplibre-gl/dist/maplibre-gl.css";
+  import style from "../assets/map/style/style.json?url";
+  import MaplibreGlDirections, { layersFactory } from "@maplibre/maplibre-gl-directions";
+
+  const name = ref(useRoute().matched[0].name);
+
+  const directions = ref<MaplibreGlDirections>();
+
+  const mapRef = ref();
+  onMounted(() => {
+    const map = new maplibregl.Map({
+      container: mapRef.value,
+      style,
+      center: [-74.1197632, 40.6974034],
+      zoom: 11,
+    });
+
+    const layers = layersFactory();
+    layers.push({
+      id: "maplibre-gl-directions-waypoint-label",
+      type: "symbol",
+      source: "maplibre-gl-directions",
+      layout: {
+        "text-field": [
+          "case",
+          ["==", ["get", "category"], "ORIGIN"],
+          "A",
+          ["==", ["get", "category"], "DESTINATION"],
+          "B",
+          "",
+        ],
+      },
+      paint: {
+        "text-color": "#ffffff",
+        "text-opacity": 0.7,
+      },
+      filter: [
+        "all",
+        ["==", ["geometry-type"], "Point"],
+        ["==", ["get", "type"], "WAYPOINT"],
+        ["in", ["get", "category"], ["literal", ["ORIGIN", "DESTINATION"]]],
+      ],
+    });
+
+    map.on("load", () => {
+      directions.value = new MaplibreGlDirections(map, {
+        requestOptions: {
+          alternatives: "true",
+        },
+        layers,
+      });
+
+      directions.value.interactive = true;
+    });
+  });
+</script>

--- a/demo/src/examples/4 Origin and Destination.vue
+++ b/demo/src/examples/4 Origin and Destination.vue
@@ -10,7 +10,7 @@
     <p>
       <strong>Note</strong> how you don't need to re-define all the layers from scratch thanks to the exported
       <code>layersFactory</code> function that returns all the default layers allowing for their augmentation and
-      modification.
+      modification
     </p>
   </app-sidebar>
 
@@ -18,7 +18,7 @@
 </template>
 
 <script setup lang="ts">
-  import { computed, onMounted, ref } from "vue";
+  import { onMounted, ref } from "vue";
   import { useRoute } from "vue-router";
   import AppSidebar from "../components/AppSidebar.vue";
   import maplibregl from "maplibre-gl";

--- a/src/directions/main.ts
+++ b/src/directions/main.ts
@@ -607,6 +607,13 @@ export default class MaplibreGlDirections {
     this.draw(false);
   }
 
+  protected assignWaypointsCategories() {
+    this._waypoints.forEach((waypoint, index) => {
+      const category = index === 0 ? "ORIGIN" : index === this._waypoints.length - 1 ? "DESTINATION" : undefined;
+      if (waypoint.properties) waypoint.properties.category = category;
+    });
+  }
+
   // the public interface begins here
 
   /**
@@ -663,6 +670,8 @@ export default class MaplibreGlDirections {
       return this.buildPoint(waypoint, "WAYPOINT");
     });
 
+    this.assignWaypointsCategories();
+
     this.draw();
     await this.fetchDirections();
   }
@@ -676,7 +685,10 @@ export default class MaplibreGlDirections {
    */
   async addWaypoint(waypoint: [number, number], index?: number) {
     index = index ?? this._waypoints.length;
+
     this._waypoints.splice(index, 0, this.buildPoint(waypoint, "WAYPOINT"));
+
+    this.assignWaypointsCategories();
 
     this.draw();
     await this.fetchDirections();
@@ -691,6 +703,8 @@ export default class MaplibreGlDirections {
   async removeWaypoint(index: number) {
     this._waypoints.splice(index, 1);
     this.snappoints.splice(index, 1);
+
+    this.assignWaypointsCategories();
 
     this.draw();
     await this.fetchDirections();


### PR DESCRIPTION
Update waypoints' properties when appropriate to include the information on whether the waypoint is origin or a destination.

Add another example that demonstrates a technique of augmenting the default layers object e.g. for styling differently the origin and the destination waypoints