### PR TITLE
Use `--access public` in `npm publish`

### DIFF
--- a/.github/workflows/build-publish-lib.yml
+++ b/.github/workflows/build-publish-lib.yml
@@ -52,13 +52,13 @@ jobs:
       - name: Publish NPM package (regular)
         if: ${{ steps.prepare_release.outputs.release_type == 'regular' }}
         run: |
-          npm publish
+          npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_ORG_TOKEN }}
 
       - name: Publish NPM package (pre-release)
         if: ${{ steps.prepare_release.outputs.release_type == 'prerelease' }}
         run: |
-          npm publish --tag next
+          npm publish --tag next --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_ORG_TOKEN }}

--- a/.github/workflows/build-publish-lib.yml
+++ b/.github/workflows/build-publish-lib.yml
@@ -52,13 +52,13 @@ jobs:
       - name: Publish NPM package (regular)
         if: ${{ steps.prepare_release.outputs.release_type == 'regular' }}
         run: |
-          npm publish --access public
+          npm publish --access public --non-interactive
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_ORG_TOKEN }}
 
       - name: Publish NPM package (pre-release)
         if: ${{ steps.prepare_release.outputs.release_type == 'prerelease' }}
         run: |
-          npm publish --tag next --access public
+          npm publish --tag next --access public --non-interactive
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_ORG_TOKEN }}


### PR DESCRIPTION
Currently, we get this error when trying to publish to npm:

```
npm ERR! 402 Payment Required - PUT https://registry.npmjs.org/@maplibre%2fmaplibre-gl-directions - You must sign up for private packages
```

With this change, it should make it clear that the package is public. See https://stackoverflow.com/a/44862841

Thanks @nyurik for granting me access to the org secrets! I have shared the npm token with this repo now.﻿
