### PR TITLE
Fix broken images URLs for the README and add project metadata to the package.json file (to reflect it at the NPM website) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A plugin to show routing directions on a MapLibre GL JS map. Supports any [OSRM](http://project-osrm.org/) or [Mapbox Directions API](https://docs.mapbox.com/api/navigation/directions/) compatible Routing-provider.
 
-![1st Demo Screenshot](demo/src/assets/screenshots/1.png)
-![2nd Demo Screenshot](demo/src/assets/screenshots/2.png)
-![3rd Demo Screenshot](demo/src/assets/screenshots/3.png)
+![1st Demo Screenshot](https://raw.githubusercontent.com/maplibre/maplibre-gl-directions/main/demo/src/assets/screenshots/1.png)
+![2nd Demo Screenshot](https://raw.githubusercontent.com/maplibre/maplibre-gl-directions/main/demo/src/assets/screenshots/2.png)
+![3rd Demo Screenshot](https://raw.githubusercontent.com/maplibre/maplibre-gl-directions/main/demo/src/assets/screenshots/3.png)
 
 [Live Demo](https://maplibre.org/maplibre-gl-directions/#/).
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "@maplibre/maplibre-gl-directions",
   "version": "0.1.2",
   "license": "MIT",
+  "homepage": "https://maplibre.org/maplibre-gl-directions/#/",
+  "repository": "https://github.com/maplibre/maplibre-gl-directions",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maplibre/maplibre-gl-directions",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "MIT",
   "files": [
     "dist"


### PR DESCRIPTION
Use GitHub raw URLs to for the README demo-images. Should close #15 