### PR TITLE
Automate GitHub Releases

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,5 +1,3 @@
-# .github/release.yml
-
 changelog:
   exclude:
     labels:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,20 @@
+# .github/release.yml
+
+changelog:
+  exclude:
+    labels:
+      - "ignore for release"
+
+  categories:
+    - title: Breaking Changes ⚠
+      labels:
+        - "breaking change"
+    - title: Exciting New Features 🎉
+      labels:
+        - enhancement
+    - title: Bug Fixes 🐛
+      labels:
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/build-publish-lib.yml
+++ b/.github/workflows/build-publish-lib.yml
@@ -1,8 +1,6 @@
 name: Build and Publish the Library
 on:
-  push:
-    branches:
-      - test-gh-releases
+  workflow_dispatch
 
 jobs:
   build-and-deploy-lib:

--- a/.github/workflows/build-publish-lib.yml
+++ b/.github/workflows/build-publish-lib.yml
@@ -1,6 +1,8 @@
 name: Build and Publish the Library
 on:
-  workflow_dispatch
+  push:
+    branches:
+      - test-gh-releases
 
 jobs:
   build-and-deploy-lib:
@@ -62,3 +64,37 @@ jobs:
           npm publish --tag next --access public --non-interactive
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_ORG_TOKEN }}
+
+      - name: Create Archive
+        run: |
+          zip -r dist dist
+
+      - name: Create GitHub Release (regular)
+        id: create_regular_release
+        if: ${{ steps.prepare_release.outputs.release_type == 'regular' }}
+        uses: ncipollo/release-action@v1.10.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag: ${{ steps.prepare_release.outputs.version_tag }}
+          name: ${{steps.prepare_release.outputs.version_tag }}
+          generateReleaseNotes: true
+          draft: false
+          prerelease: false
+          artifacts: "./dist.zip"
+          artifactContentType: "application/zip"
+
+      - name: Create GitHub Release (prerelease)
+        id: create_prerelease
+        if: ${{ steps.prepare_release.outputs.release_type == 'prerelease' }}
+        uses: ncipollo/release-action@v1.10.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag: ${{ steps.prepare_release.outputs.version_tag }}
+          name: ${{steps.prepare_release.outputs.version_tag }}
+          generateReleaseNotes: true
+          draft: false
+          prerelease: true
+          bodyFile: ./dist.zip
+          artifactContentType: "application/zip"

--- a/.github/workflows/build-publish-lib.yml
+++ b/.github/workflows/build-publish-lib.yml
@@ -94,5 +94,5 @@ jobs:
           generateReleaseNotes: true
           draft: false
           prerelease: true
-          bodyFile: ./dist.zip
+          artifacts: "./dist.zip"
           artifactContentType: "application/zip"


### PR DESCRIPTION
This PR automates GitHub Releases. When the main action (build and deploy lib) is dispatched, it also creates a new GitHub release.

Should close #19 