### PR TITLE
Update the release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -8,7 +8,7 @@ changelog:
       labels:
         - "semver:major"
 
-    - title: Minor Updates (New Features 🎉 and other non-breacking API changes)
+    - title: Minor Updates (New Features 🎉 and other non-breaking API changes)
       labels:
         - "semver:minor"
 

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,15 +4,14 @@ changelog:
       - "release:ignore"
 
   categories:
-    - title: Breaking Changes ⚠
+    - title: Major Updates (Breaking Changes ⚠)
       labels:
         - "semver:major"
-    - title: Exciting New Features 🎉
+
+    - title: Minor Updates (New Features 🎉 and other non-breacking API changes)
       labels:
         - "semver:minor"
-    - title: Bug Fixes 🐛
+
+    - title: Patches (Bug Fixes 🐛, refactoring, and other changes that don't affect the existing API)
       labels:
         - "semver:patch"
-    - title: Other Changes
-      labels:
-        - "*"


### PR DESCRIPTION
Patch releases are not necessarily bug fixes; minor releases are not necessarily new features. Update the release-notes generation process accordingly.

Also, there must be a semver-related label attached to a PR, and if neither patch nor minor no major update is applied, the release notes for it should be hidden. Therefore, the "Other changes" section is always empty -> remove it.