### PR TITLE
Hotfix: fix broken examples

### DIFF
--- a/demo/src/examples/3 Mapbox Directions API and Congestions.svelte
+++ b/demo/src/examples/3 Mapbox Directions API and Congestions.svelte
@@ -29,7 +29,7 @@
     });
   });
 
-  $: if (map) {
+  $: if (map && directions) {
     if (directions) directions.destroy();
 
     directions = new MapLibreGlDirections(map, {

--- a/demo/src/examples/6 Touch-Friendly Features.svelte
+++ b/demo/src/examples/6 Touch-Friendly Features.svelte
@@ -33,7 +33,7 @@
     });
   });
 
-  $: if (map) {
+  $: if (map && directions) {
     if (directions) directions.destroy();
 
     const layers = layersFactory(isTouchDevice ? 1.5 : 1, isTouchDevice ? 2 : 1);

--- a/demo/src/examples/8 Loading Indicator Control.svelte
+++ b/demo/src/examples/8 Loading Indicator Control.svelte
@@ -37,7 +37,7 @@
   let control: LoadingIndicatorControl;
   let position: ControlPosition = "top-right";
 
-  $: if (map) {
+  $: if (map && directions) {
     if (control && map.hasControl(control)) map.removeControl(control);
     map.addControl((control = new LoadingIndicatorControl(directions, { class: "m-2" })), position);
   }


### PR DESCRIPTION
Fix 8th example.

After switching from Vue to Svelte there appeared a bug because of which the 8th example gets broken. The other examples are fixed analogically just in case, even though they are not broken right away.

For some reason TypeScript thinks that `directions` can't be `undifined` (while in fact it is and therefore the app is broken in runtime).