### PR TITLE
Re-enable plugin's disabled interactivity even if a routing-request fails. Equalize routing and other errors.

### DIFF
--- a/src/directions/events.ts
+++ b/src/directions/events.ts
@@ -152,7 +152,8 @@ export class MapLibreGlDirectionsRoutingEvent implements MapLibreGlDirectionsEve
   /**
    * The server's response.
    *
-   * Only presents when it's the {@link MapLibreGlDirectionsEventType.fetchroutesend|`fetchroutesend`} event.
+   * Only presents when it's the {@link MapLibreGlDirectionsEventType.fetchroutesend|`fetchroutesend`} event, but might
+   * be `undefined` in case the request to fetch directions failed.
    *
    * @see http://project-osrm.org/docs/v5.24.0/api/#responses
    */

--- a/src/directions/types.ts
+++ b/src/directions/types.ts
@@ -274,7 +274,8 @@ export type PointType = "WAYPOINT" | "SNAPPOINT" | "HOVERPOINT" | string;
 // server response. Only the necessary for the plugin fields
 
 export interface Directions {
-  code: string;
+  code: "Ok" | string;
+  message?: string;
   routes: Route[];
   waypoints: Snappoint[];
 }


### PR DESCRIPTION
Instead of #76. Closes #25.