### PR TITLE
Revert OSRM links to use HTTP protocol

### DIFF
--- a/demo/src/examples/1 User Interaction.svelte
+++ b/demo/src/examples/1 User Interaction.svelte
@@ -20,7 +20,7 @@
       style,
       center: [-74.1197632, 40.6974034],
       zoom: 11,
-      customAttribution: "<a href='//project-osrm.org/' target='_blank'>&copy; OSRM</a>",
+      customAttribution: "<a href='http://project-osrm.org/' target='_blank'>&copy; OSRM</a>",
     });
 
     map.on("load", () => {

--- a/demo/src/examples/2 Programmatical Control.svelte
+++ b/demo/src/examples/2 Programmatical Control.svelte
@@ -20,7 +20,7 @@
       style,
       center: [-74.1197632, 40.6974034],
       zoom: 11,
-      customAttribution: "<a href='//project-osrm.org/' target='_blank'>&copy; OSRM</a>",
+      customAttribution: "<a href='http://project-osrm.org/' target='_blank'>&copy; OSRM</a>",
     });
 
     _map.on("load", () => {

--- a/demo/src/examples/4 Origin and Destination.svelte
+++ b/demo/src/examples/4 Origin and Destination.svelte
@@ -19,7 +19,7 @@
       style,
       center: [-74.1197632, 40.6974034],
       zoom: 11,
-      customAttribution: "<a href='//project-osrm.org/' target='_blank'>&copy; OSRM</a>",
+      customAttribution: "<a href='http://project-osrm.org/' target='_blank'>&copy; OSRM</a>",
     });
 
     const layers = layersFactory();

--- a/demo/src/examples/5 Show Routes' Directions.svelte
+++ b/demo/src/examples/5 Show Routes' Directions.svelte
@@ -20,7 +20,7 @@
       style,
       center: [-74.1197632, 40.6974034],
       zoom: 11,
-      customAttribution: "<a href='//project-osrm.org/' target='_blank'>&copy; OSRM</a>",
+      customAttribution: "<a href='http://project-osrm.org/' target='_blank'>&copy; OSRM</a>",
     });
 
     map.loadImage(DirectionArrowImageSrc, (error, image) => {

--- a/demo/src/examples/6 Touch-Friendly Features.svelte
+++ b/demo/src/examples/6 Touch-Friendly Features.svelte
@@ -24,7 +24,7 @@
       style,
       center: [-74.1197632, 40.6974034],
       zoom: 11,
-      customAttribution: "<a href='//project-osrm.org/' target='_blank'>&copy; OSRM</a>",
+      customAttribution: "<a href='http://project-osrm.org/' target='_blank'>&copy; OSRM</a>",
     });
 
     _map.on("load", () => {

--- a/demo/src/examples/7 Events.svelte
+++ b/demo/src/examples/7 Events.svelte
@@ -20,7 +20,7 @@
       style,
       center: [-74.1197632, 40.6974034],
       zoom: 11,
-      customAttribution: "<a href='//project-osrm.org/' target='_blank'>&copy; OSRM</a>",
+      customAttribution: "<a href='http://project-osrm.org/' target='_blank'>&copy; OSRM</a>",
     });
 
     map.on("load", () => {

--- a/demo/src/examples/8 Aborting Requests.svelte
+++ b/demo/src/examples/8 Aborting Requests.svelte
@@ -22,7 +22,7 @@
       style,
       center: [-74.1197632, 40.6974034],
       zoom: 11,
-      customAttribution: "<a href='//project-osrm.org/' target='_blank'>&copy; OSRM</a>",
+      customAttribution: "<a href='http://project-osrm.org/' target='_blank'>&copy; OSRM</a>",
     });
 
     _map.on("load", () => {

--- a/demo/src/examples/9 Loading Indicator Control.svelte
+++ b/demo/src/examples/9 Loading Indicator Control.svelte
@@ -20,7 +20,7 @@
       style,
       center: [-74.1197632, 40.6974034],
       zoom: 11,
-      customAttribution: "<a href='//project-osrm.org/' target='_blank'>&copy; OSRM</a>",
+      customAttribution: "<a href='http://project-osrm.org/' target='_blank'>&copy; OSRM</a>",
     });
 
     map.on("load", () => {


### PR DESCRIPTION
Missed this one because my local dev-server serves over HTTP. Thanks for noticing, @wipfli :+1: 