### PR TITLE
Fix comments

### DIFF
--- a/src/directions/types.ts
+++ b/src/directions/types.ts
@@ -58,7 +58,7 @@ export interface MapLibreGlDirectionsConfiguration {
    *
    * @example
    * ```
-   * request: {
+   * requestOptions: {
    *   overview: "full",
    *   steps: "true"
    * }
@@ -68,7 +68,7 @@ export interface MapLibreGlDirectionsConfiguration {
    * ```
    * api: "https://api.mapbox.com/directions/v5",
    * profile: "mapbox/driving-traffic",
-   * request: {
+   * requestOptions: {
    *   access_token: "<mapbox-access-token>",
    *   annotations: "congestion",
    *   geometries: "polyline6"


### PR DESCRIPTION
Fix wrong `requestOptions` configuration option in the comments

I copy/pasted from the documentation (which is built from the comments) and I was wondering why my `request` options were not working. This should fix it.