### PR TITLE
Fix #186

### DIFF
--- a/src/directions/main.ts
+++ b/src/directions/main.ts
@@ -646,6 +646,10 @@ export default class MapLibreGlDirections extends MapLibreGlDirectionsEvented {
     this.map.on("touchstart", this.onMoveHandler);
     this.map.on("mousemove", this.onMoveHandler);
 
+    // Re-enable original dragPan functionality. Might have already been re-enabled, but there are cases when it's
+    // not the case. See https://github.com/maplibre/maplibre-gl-directions/issues/186
+    this.map.dragPan.enable();
+
     this.draw();
   }
 


### PR DESCRIPTION
Re-enable dragPan in the end of `onDragUp`. For the most cases it should already be re-enabled, but turns out that it's not guaranteed for some reason.