### PR TITLE
prevent errors when clear is called during a fetch

### DIFF
--- a/src/directions/main.ts
+++ b/src/directions/main.ts
@@ -158,7 +158,7 @@ export default class MapLibreGlDirections extends MapLibreGlDirectionsEvented {
 
       this.snappoints = response.waypoints.map((snappoint, i) =>
         this.buildPoint(snappoint.location, "SNAPPOINT", {
-          waypointProperties: this._waypoints[i].properties ?? {},
+          waypointProperties: this._waypoints[i]?.properties ?? {},
         }),
       );
 


### PR DESCRIPTION
when clear() is called, _waypoints is emptied, which could cause problems if called during a fetch, as it would prevent the waypoint data update from working.