### PR TITLE
Improve error handling

### DIFF
--- a/demo/src/examples/1 User Interaction.svelte
+++ b/demo/src/examples/1 User Interaction.svelte
@@ -45,13 +45,27 @@
     });
   });
 
+  let message;
+
   $: if (directions) {
     directions.interactive = interactive;
+
+    directions.on("fetchroutesend", (event) => {
+      if (event.data.code !== "Ok") {
+        message = `${event.data.code}: ${event.data.message ?? "no details available."}`;
+      } else {
+        message = "";
+      }
+    });
   }
 </script>
 
 <AppSidebar>
   <span slot="title">{meta.name}</span>
+
+  {#if message}
+    <p class="text-red-500">{message}</p>
+  {/if}
 
   <label class="flex items-center gap-3">
     <input type="checkbox" bind:checked={interactive} disabled={!directions} />

--- a/src/directions/main.ts
+++ b/src/directions/main.ts
@@ -686,14 +686,11 @@ export default class MapLibreGlDirections extends MapLibreGlDirectionsEvented {
           initialCoordinates: this.waypointBeingDraggedInitialCoordinates,
         });
         this.fire(waypointEvent);
-        /*
-         * If the routing request has failed for some reason, restore the waypoint's original position.
-         */
+
         try {
           await this.fetchDirections(waypointEvent);
         } catch (err) {
-          // If the request fails we need to catch the exception for it not to bubble up
-          // even though we don't intend on doing anything with it
+          // noop
         }
       }
       this.refreshOnMoveIsRefreshing = false;
@@ -798,7 +795,12 @@ export default class MapLibreGlDirections extends MapLibreGlDirectionsEvented {
     this.fire(waypointEvent);
 
     this.draw();
-    await this.fetchDirections(waypointEvent);
+
+    try {
+      await this.fetchDirections(waypointEvent);
+    } catch (err) {
+      // noop
+    }
   }
 
   protected async _removeWaypoint(index: number, originalEvent?: MapMouseEvent | MapTouchEvent) {
@@ -815,7 +817,12 @@ export default class MapLibreGlDirections extends MapLibreGlDirectionsEvented {
     this.fire(waypointEvent);
 
     this.draw();
-    await this.fetchDirections(waypointEvent);
+
+    try {
+      await this.fetchDirections(waypointEvent);
+    } catch (err) {
+      // noop
+    }
   }
 
   // the public interface begins here
@@ -900,7 +907,12 @@ export default class MapLibreGlDirections extends MapLibreGlDirectionsEvented {
     this.fire(waypointEvent);
 
     this.draw();
-    this.fetchDirections(waypointEvent);
+
+    try {
+      this.fetchDirections(waypointEvent);
+    } catch (err) {
+      // noop
+    }
   }
 
   /**
@@ -930,7 +942,12 @@ export default class MapLibreGlDirections extends MapLibreGlDirectionsEvented {
     this.fire(waypointEvent);
 
     this.draw();
-    await this.fetchDirections(waypointEvent);
+
+    try {
+      await this.fetchDirections(waypointEvent);
+    } catch (err) {
+      // noop
+    }
   }
 
   /**


### PR DESCRIPTION
Here and below the "error" means any server response with `code` different from `"Ok"`.

The issue with the existing implementation is that sometimes the error is handled and sometimes it's not. Therefore, sometimes it bubbles to the consumer code and sometimes that doesn't happen. That brings inconsistencies to the plugin's behavior.

Proposed solution: don't allow errors to ever bubble up to the consuming code. All the invocations of `fetchDirections` should be done inside `try`-`catch` blocks and, when necessary (currently there's only 1 such occasion), the error should be handled appropriately.

**Also**, updated the first example to display an error message (if any) using the plugin's events interface. To get an error, try e.g. to build a route from North America to Africa.