### PR TITLE
Fix SVGs (Bearings Control) in Firefox

### DIFF
--- a/src/controls/bearings/BearingsControl.svelte
+++ b/src/controls/bearings/BearingsControl.svelte
@@ -144,7 +144,7 @@
               fill="transparent"
               stroke="rgba(109, 38, 215, 0.65)"
               stroke-width="10"
-              stroke-dasharray="calc({waypointBearing.degrees / 3.6} * 31.42 / 100) 31.42"
+              stroke-dasharray="{((waypointBearing.degrees / 3.6) * 31.42) / 100} 31.42"
               transform="rotate({-90 - waypointBearing.degrees / 2 + waypointBearing.angle - angleAdjustment})"
               style="transform-origin: 10px 10px"
             />


### PR DESCRIPTION
Firefox: fix

![Screenshot_20230223_170110](https://user-images.githubusercontent.com/9782236/220875626-d17650a5-e650-4e55-8c72-2b2c8c380e9c.png)

to be

![Screenshot_20230223_170130](https://user-images.githubusercontent.com/9782236/220875690-399a4f77-ac94-4d03-ad34-8f6cb1b514c9.png)

via getting rid of `calc()` in `stroke-dasharray`.