### PR TITLE
Fix #209

### DIFF
--- a/src/directions/utils.ts
+++ b/src/directions/utils.ts
@@ -208,6 +208,8 @@ export function buildRoutelines(
       .map((snappointLngLat) => {
         // use the currentIndex to start the search from the place where the last snappoint's coordinate was found
         const waypointCoordinatesIndex = coordinates.slice(currentIndex).findIndex((lngLat) => {
+          // there might be an error in 0.00001 degree between snappoint and decoded coordinate when using the
+          // "polyline" geometries. The comparator neglects that
           return coordinatesComparator(requestOptions, lngLat, snappointLngLat as [number, number]);
         });
 

--- a/src/directions/utils.ts
+++ b/src/directions/utils.ts
@@ -200,16 +200,25 @@ export function buildRoutelines(
     // get coordinates from the snappoint-features
     const snappointsCoordinates = snappoints.map((snappoint) => snappoint.geometry.coordinates);
 
+    // add a variable to watch the current index to start the search from
+    let currentIndex = 0;
+
     // indices of coordinate pairs that match existing snappoints (except for the first one)
     const snappointsCoordinatesIndices = snappointsCoordinates
       .map((snappointLngLat) => {
-        return coordinates.findIndex((lngLat) => {
-          // there might be an error in 0.00001 degree between snappoint and decoded coordinate when using the
-          // "polyline" geometries. The comparator neglects that
+        // use the currentIndex to start the search from the place where the last snappoint's coordinate was found
+        const waypointCoordinatesIndex = coordinates.slice(currentIndex).findIndex((lngLat) => {
           return coordinatesComparator(requestOptions, lngLat, snappointLngLat as [number, number]);
         });
+
+        // update the current index if something's found
+        if (waypointCoordinatesIndex !== -1) {
+          currentIndex += waypointCoordinatesIndex;
+        }
+
+        return currentIndex;
       })
-      .slice(1); // because the first one is always 0
+      .slice(1); // because the first one is always 0 (first leg always starts with the first snappoint)
 
     // split the coordinates array by legs. Each leg consists of coordinates between snappoints
     let initialIndex = 0;


### PR DESCRIPTION
The solution briefly:

In order to build the polyline features used to render the lines on the map, we can't take the full resulting geometry, because we need to be able to highlight individual route legs when those are hovered. In order to build the legs, we first first decode the final routeline to get a list of individual coordinates through which the lines go and then compare the coordinates with the snappoints' coordinates. When there's a match, we "break" the route line into 2 individual route legs.

There was a bug, that when looking for coordinates that are the same (snappoint's coordinate the same as the current routeline's coordinate), we started the search everytime from the beginning of the route's coordinates. Therefore, for different snappoints with the same location, we took the same "portion" of a routeline, creating a total mess on the map. This fix changes the algorithm to search for the next snappoint from the index where the last search succeeded.

This PR closes #209 