### PR TITLE
Feature: Allow hover effects and route switching in non-interactive mode

### DIFF
--- a/demo/src/examples/1 User Interaction.svelte
+++ b/demo/src/examples/1 User Interaction.svelte
@@ -14,6 +14,8 @@
   let map: maplibregl.Map | undefined = undefined;
   let directions: MapLibreGlDirections | undefined = undefined;
   let interactive = true;
+  let hoverable = false;
+  let routeSwitch = false;
   let refreshOnMove = false;
 
   function changeRefreshOnMove() {
@@ -48,7 +50,15 @@
   let message;
 
   $: if (directions) {
-    directions.interactive = interactive;
+    if (directions.hoverable !== hoverable) {
+      directions.hoverable = hoverable;
+    }
+    if (directions.interactive !== interactive) {
+      directions.interactive = interactive;
+    }
+    if (directions.allowRouteSwitch !== routeSwitch) {
+      directions.allowRouteSwitch = routeSwitch;
+    }
 
     directions.on("fetchroutesend", (event) => {
       if (event.data.code !== "Ok") {
@@ -70,6 +80,16 @@
   <label class="flex items-center gap-3">
     <input type="checkbox" bind:checked={interactive} disabled={!directions} />
     <strong>Interactivity enabled</strong>
+  </label>
+
+  <label class="flex items-center gap-3">
+    <input type="checkbox" bind:checked={hoverable} disabled={!directions} />
+    <strong>Hover enabled</strong>
+  </label>
+
+  <label class="flex items-center gap-3 ml-5">
+    <input type="checkbox" bind:checked={routeSwitch} disabled={!directions || !hoverable} />
+    <strong>Route switch</strong>
   </label>
 
   <label class="flex items-center gap-3">


### PR DESCRIPTION
This PR adds foolowing changes to the public API:

1. `hoverable` flag. Allows hover effects in non-interactive mode. Can be set to `true` while `interactive` is `false` for the features to be highlighted when hovered over by the user. Does nothing when `interactive` is `true`.
2. `allowRouteSwitch` flag. Allows user to switch to alternative routes while in non-interactive mode. Only takes effect when `hoverable` is `true`.