### PR TITLE
Bug fix: Fixed route line building

### DIFF
--- a/src/directions/utils.ts
+++ b/src/directions/utils.ts
@@ -207,7 +207,7 @@ export function buildRoutelines(
 
     // indices of coordinate pairs that match existing snappoints (except for the first one)
     const snappointsCoordinatesIndices = snappointsCoordinates
-      .map((snappointLngLat) => {
+      .map((snappointLngLat, index) => {
         // use the currentIndex to start the search from the place where the last snappoint's coordinate was found
         const waypointCoordinatesIndex = coordinates.slice(currentIndex).findIndex((lngLat) => {
           // there might be an error in 0.00001 degree between snappoint and decoded coordinate when using the
@@ -215,9 +215,13 @@ export function buildRoutelines(
           return coordinatesComparator(requestOptions, lngLat, snappointLngLat as [number, number]);
         });
 
+        const isLast = index === snappointsCoordinates.length - 1;
+
         // update the current index if something's found
         if (waypointCoordinatesIndex !== -1) {
           currentIndex += waypointCoordinatesIndex;
+        } else if (isLast) {
+          return coordinates.length - 1;
         }
 
         return currentIndex;


### PR DESCRIPTION
**Bug**
If route line's coordinates don't match with the final snap point, the remaining coordinates are not added to the outpur geometry. If there's only two snappoints and the last is not found the resulting geometry's coordinates consists of only one point and the line is not being drawn.

**Solution**
Fixed `buildRoutelines` method to account for this edge case