### PR TITLE
Set category of route midpoints as "WAYPOINT" instead of undefined

### DIFF
--- a/src/directions/main.ts
+++ b/src/directions/main.ts
@@ -883,7 +883,7 @@ export default class MapLibreGlDirections extends MapLibreGlDirectionsEvented {
 
   protected assignWaypointsCategories() {
     this._waypoints.forEach((waypoint, index) => {
-      const category = index === 0 ? "ORIGIN" : index === this._waypoints.length - 1 ? "DESTINATION" : undefined;
+      const category = index === 0 ? "ORIGIN" : index === this._waypoints.length - 1 ? "DESTINATION" : "WAYPOINT";
 
       if (waypoint.properties) {
         waypoint.properties.index = index;


### PR DESCRIPTION
This is needed for compatibility with maplibre-gl >= 5.12, which errors out on feature properties with a value of `undefined`: https://github.com/maplibre/maplibre-gl-js/issues/6730

The change doesn't have side effects on maplibre-gl-directions itself.